### PR TITLE
Kirkstone migration and updates

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,3 +12,4 @@ BBFILE_PRIORITY_meta-microservicebus-intel-nuc = "6"
 LAYERDEPENDS_meta-microservicebus-intel-nuc = "core"
 LAYERSERIES_COMPAT_meta-microservicebus-intel-nuc = "kirkstone"
 
+ROOT_BLOCK_DEVICE_NAME ?= "nvme0n1"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,5 +10,5 @@ BBFILE_PATTERN_meta-microservicebus-intel-nuc = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-microservicebus-intel-nuc = "6"
 
 LAYERDEPENDS_meta-microservicebus-intel-nuc = "core"
-LAYERSERIES_COMPAT_meta-microservicebus-intel-nuc = "dunfell"
+LAYERSERIES_COMPAT_meta-microservicebus-intel-nuc = "kirkstone"
 

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -11,5 +11,3 @@ BBFILE_PRIORITY_meta-microservicebus-intel-nuc = "6"
 
 LAYERDEPENDS_meta-microservicebus-intel-nuc = "core"
 LAYERSERIES_COMPAT_meta-microservicebus-intel-nuc = "kirkstone"
-
-ROOT_BLOCK_DEVICE_NAME ?= "nvme0n1"

--- a/recipes-bsp/grub/files/grub.cfg
+++ b/recipes-bsp/grub/files/grub.cfg
@@ -41,7 +41,7 @@ fi
 save_env --file=(hd0,1)/grubenv A_TRY A_OK B_TRY B_OK ORDER
 
 # For more logs add "loglevel=7" to CMDLINE
-CMDLINE="@BOOT_CMDLINE@"
+CMDLINE="@GRUB_RAUC_BOOT_CMD@"
 ROOT_BLOCK_DEVICE_NAME="@ROOT_BLOCK_DEVICE_NAME@"
 
 menuentry "Slot A (OK=$A_OK TRY=$A_TRY)" {

--- a/recipes-bsp/grub/files/grub.cfg
+++ b/recipes-bsp/grub/files/grub.cfg
@@ -42,12 +42,13 @@ save_env --file=(hd0,1)/grubenv A_TRY A_OK B_TRY B_OK ORDER
 
 # For more logs add "loglevel=7" to CMDLINE
 CMDLINE="@BOOT_CMDLINE@"
+ROOT_BLOCK_DEVICE_NAME="@ROOT_BLOCK_DEVICE_NAME@"
 
 menuentry "Slot A (OK=$A_OK TRY=$A_TRY)" {
-    linux (hd0,2)/boot/bzImage root=/dev/@ROOT_BLOCK_DEVICE_NAME@p2 $CMDLINE rauc.slot=A
+    linux (hd0,2)/boot/bzImage root=/dev/${ROOT_BLOCK_DEVICE_NAME}p2 $CMDLINE rauc.slot=A
 }
 
 menuentry "Slot B (OK=$B_OK TRY=$B_TRY)" {
-    linux (hd0,3)/boot/bzImage root=/dev/@ROOT_BLOCK_DEVICE_NAME@p3 $CMDLINE rauc.slot=B
+    linux (hd0,3)/boot/bzImage root=/dev/${ROOT_BLOCK_DEVICE_NAME}p3 $CMDLINE rauc.slot=B
 }
 

--- a/recipes-bsp/grub/files/grub.cfg
+++ b/recipes-bsp/grub/files/grub.cfg
@@ -40,13 +40,14 @@ fi
 
 save_env --file=(hd0,1)/grubenv A_TRY A_OK B_TRY B_OK ORDER
 
-CMDLINE="console=ttyS0,115200 net.ifnames=0 panic=60"
+# For more logs add "loglevel=7" to CMDLINE
+CMDLINE="@BOOT_CMDLINE@"
 
 menuentry "Slot A (OK=$A_OK TRY=$A_TRY)" {
-    linux (hd0,2)/boot/bzImage root=/dev/nvme0n1p2 $CMDLINE rauc.slot=A
+    linux (hd0,2)/boot/bzImage root=/dev/@ROOT_BLOCK_DEVICE_NAME@p2 $CMDLINE rauc.slot=A
 }
 
 menuentry "Slot B (OK=$B_OK TRY=$B_TRY)" {
-    linux (hd0,3)/boot/bzImage root=/dev/nvme0n1p3 $CMDLINE rauc.slot=B
+    linux (hd0,3)/boot/bzImage root=/dev/@ROOT_BLOCK_DEVICE_NAME@p3 $CMDLINE rauc.slot=B
 }
 

--- a/recipes-bsp/grub/rauc-qemu-grubconf.bb
+++ b/recipes-bsp/grub/rauc-qemu-grubconf.bb
@@ -12,14 +12,14 @@ SRC_URI += " \
 
 S = "${WORKDIR}"
 
-BOOT_CMDLINE ?= "console=ttyS0,115200 net.ifnames=0 panic=60"
+GRUB_RAUC_BOOT_CMD ?= "console=ttyS0,115200 net.ifnames=0 panic=60"
 
 inherit deploy
 
 do_install() {
   # Replace root block device name and boot cmdline parameters
   sed -i -e 's:@ROOT_BLOCK_DEVICE_NAME@:${ROOT_BLOCK_DEVICE_NAME}:g' ${WORKDIR}/grub.cfg
-  sed -i -e 's:@BOOT_CMDLINE@:${BOOT_CMDLINE}:g' ${WORKDIR}/grub.cfg
+  sed -i -e 's:@GRUB_RAUC_BOOT_CMD@:${GRUB_RAUC_BOOT_CMD}:g' ${WORKDIR}/grub.cfg
 
   # Install grub.cfg file
   install -d ${D}${EFI_FILES_PATH}

--- a/recipes-bsp/grub/rauc-qemu-grubconf.bb
+++ b/recipes-bsp/grub/rauc-qemu-grubconf.bb
@@ -13,6 +13,7 @@ SRC_URI += " \
 S = "${WORKDIR}"
 
 GRUB_RAUC_BOOT_CMD ?= "console=ttyS0,115200 net.ifnames=0 panic=60"
+ROOT_BLOCK_DEVICE_NAME ?= "nvme0n1"
 
 inherit deploy
 

--- a/recipes-bsp/grub/rauc-qemu-grubconf.bb
+++ b/recipes-bsp/grub/rauc-qemu-grubconf.bb
@@ -12,11 +12,18 @@ SRC_URI += " \
 
 S = "${WORKDIR}"
 
+BOOT_CMDLINE ?= "console=ttyS0,115200 net.ifnames=0 panic=60"
+
 inherit deploy
 
 do_install() {
-        install -d ${D}${EFI_FILES_PATH}
-        install -m 644 ${WORKDIR}/grub.cfg ${D}${EFI_FILES_PATH}/grub.cfg
+  # Replace root block device name and boot cmdline parameters
+  sed -i -e 's:@ROOT_BLOCK_DEVICE_NAME@:${ROOT_BLOCK_DEVICE_NAME}:g' ${WORKDIR}/grub.cfg
+  sed -i -e 's:@BOOT_CMDLINE@:${BOOT_CMDLINE}:g' ${WORKDIR}/grub.cfg
+
+  # Install grub.cfg file
+  install -d ${D}${EFI_FILES_PATH}
+  install -m 644 ${WORKDIR}/grub.cfg ${D}${EFI_FILES_PATH}/grub.cfg
 }
 
 FILES:${PN} = "${EFI_FILES_PATH}/grub.cfg"

--- a/recipes-bsp/grub/rauc-qemu-grubconf.bb
+++ b/recipes-bsp/grub/rauc-qemu-grubconf.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384
 
 include conf/image-uefi.conf
 
-RPROVIDES_${PN} += "virtual/grub-bootconf"
+RPROVIDES:${PN} = "virtual-grub-bootconf"
 
 SRC_URI += " \
     file://grub.cfg \
@@ -19,7 +19,7 @@ do_install() {
         install -m 644 ${WORKDIR}/grub.cfg ${D}${EFI_FILES_PATH}/grub.cfg
 }
 
-FILES_${PN} += "${EFI_FILES_PATH}"
+FILES:${PN} = "${EFI_FILES_PATH}/grub.cfg"
 
 do_deploy() {
 	install -m 644 ${WORKDIR}/grub.cfg ${DEPLOYDIR}

--- a/recipes-core/base-files/base-files/fstab
+++ b/recipes-core/base-files/base-files/fstab
@@ -7,6 +7,6 @@ tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,stri
 tmpfs                /var/volatile        tmpfs      defaults              0  0
 
 # Add mount for boot, grubenv and data partition
-/dev/nvme0n1p1            /grubenv             auto       defaults,sync  0  0
-/dev/nvme0n1p4            /data                auto       defaults,sync  0  0
+/dev/@ROOT_BLOCK_DEVICE_NAME@p1            /grubenv             auto       defaults,sync  0  0
+/dev/@ROOT_BLOCK_DEVICE_NAME@p4            /data                auto       defaults,sync  0  0
 

--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -3,3 +3,8 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 # Add a mount point for a shared data partition
 dirs755 += "/data"
 dirs755 += "/grubenv"
+
+do_install:prepend () {
+  # Replace root block device name parameters
+  sed -i -e 's:@ROOT_BLOCK_DEVICE_NAME@:${ROOT_BLOCK_DEVICE_NAME}:g' ${WORKDIR}/fstab
+}

--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -4,6 +4,8 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 dirs755 += "/data"
 dirs755 += "/grubenv"
 
+ROOT_BLOCK_DEVICE_NAME ?= "nvme0n1"
+
 do_install:prepend () {
   # Replace root block device name parameters
   sed -i -e 's:@ROOT_BLOCK_DEVICE_NAME@:${ROOT_BLOCK_DEVICE_NAME}:g' ${WORKDIR}/fstab

--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -1,4 +1,4 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 
 # Add a mount point for a shared data partition
 dirs755 += "/data"

--- a/recipes-core/initrdscripts/initramfs-module-install-efi/init-install-efi.sh
+++ b/recipes-core/initrdscripts/initramfs-module-install-efi/init-install-efi.sh
@@ -80,7 +80,7 @@ if [ -z "${hdnamelist}" ]; then
 fi
 
 # Set static install target
-TARGET_DEVICE_NAME="nvme0n1"
+TARGET_DEVICE_NAME="@ROOT_BLOCK_DEVICE_NAME@"
 
 for hdname in $hdnamelist; do
     # Display found hard drives and their basic info

--- a/recipes-core/initrdscripts/initramfs-module-install-efi_1.0.bbappend
+++ b/recipes-core/initrdscripts/initramfs-module-install-efi_1.0.bbappend
@@ -1,2 +1,2 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 

--- a/recipes-core/initrdscripts/initramfs-module-install-efi_1.0.bbappend
+++ b/recipes-core/initrdscripts/initramfs-module-install-efi_1.0.bbappend
@@ -1,2 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
+do_install:prepend () {
+  # Replace root block device name parameters
+  sed -i -e 's:@ROOT_BLOCK_DEVICE_NAME@:${ROOT_BLOCK_DEVICE_NAME}:g' ${WORKDIR}/init-install-efi.sh
+}

--- a/recipes-core/initrdscripts/initramfs-module-install-efi_1.0.bbappend
+++ b/recipes-core/initrdscripts/initramfs-module-install-efi_1.0.bbappend
@@ -1,5 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
+ROOT_BLOCK_DEVICE_NAME ?= "nvme0n1"
+
 do_install:prepend () {
   # Replace root block device name parameters
   sed -i -e 's:@ROOT_BLOCK_DEVICE_NAME@:${ROOT_BLOCK_DEVICE_NAME}:g' ${WORKDIR}/init-install-efi.sh

--- a/recipes-core/intel-nuc-init/intel-nuc-init_0.0.1.bb
+++ b/recipes-core/intel-nuc-init/intel-nuc-init_0.0.1.bb
@@ -11,9 +11,9 @@ S = "${WORKDIR}"
 
 SYSTEMD_PACKAGES = "${PN}"
 
-SYSTEMD_SERVICE_${PN} = " intel-nuc-init.service"
+SYSTEMD_SERVICE:${PN} = " intel-nuc-init.service"
 
-FILES_${PN} += "${systemd_system_unitdir}/intel-nuc-init.service \
+FILES:${PN} += "${systemd_system_unitdir}/intel-nuc-init.service \
                 ${bindir}/intel-nuc-init.sh"
 
 do_install() {
@@ -29,4 +29,4 @@ do_install() {
 
 REQUIRED_DISTRO_FEATURES= "systemd"
 
-RDEPENDS_${PN} = "dmidecode"
+RDEPENDS:${PN} = "dmidecode"

--- a/recipes-core/rauc/files/intel-corei7-64/system.conf
+++ b/recipes-core/rauc/files/intel-corei7-64/system.conf
@@ -8,11 +8,11 @@ statusfile=/data/rauc.status
 path=ca.cert.pem
 
 [slot.rootfs.0]
-device=/dev/nvme0n1p2
+device=/dev/@ROOT_BLOCK_DEVICE_NAME@p2
 type=ext4
 bootname=A
 
 [slot.rootfs.1]
-device=/dev/nvme0n1p3
+device=/dev/@ROOT_BLOCK_DEVICE_NAME@p3
 type=ext4
 bootname=B

--- a/recipes-core/rauc/files/intel-corei7-64/system.conf
+++ b/recipes-core/rauc/files/intel-corei7-64/system.conf
@@ -1,5 +1,5 @@
 [system]
-compatible=intel-i7-x64-nuc-msb-rauc
+compatible=@MSB_BUNDLE_COMPATIBLE@
 bootloader=grub
 grubenv=/grubenv/grubenv
 statusfile=/data/rauc.status

--- a/recipes-core/rauc/rauc_rauc.inc
+++ b/recipes-core/rauc/rauc_rauc.inc
@@ -1,4 +1,4 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 # additional dependencies required to run RAUC on the target
-RDEPENDS_${PN} += "grub-editenv e2fsprogs-mke2fs"
+RDEPENDS:${PN} += "grub-editenv e2fsprogs-mke2fs"

--- a/recipes-core/rauc/rauc_rauc.inc
+++ b/recipes-core/rauc/rauc_rauc.inc
@@ -3,7 +3,13 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 # additional dependencies required to run RAUC on the target
 RDEPENDS:${PN} += "grub-editenv e2fsprogs-mke2fs"
 
+# Define compatible bundles (by default, same as RAUC)
+MSB_BUNDLE_COMPATIBLE ?= "${RAUC_BUNDLE_COMPATIBLE}"
+
 do_install:prepend () {
   # Replace root block device name parameters
   sed -i -e 's:@ROOT_BLOCK_DEVICE_NAME@:${ROOT_BLOCK_DEVICE_NAME}:g' ${WORKDIR}/system.conf
+
+  # Replace compatible bundle parameter
+  sed -i -e 's:@MSB_BUNDLE_COMPATIBLE@:${MSB_BUNDLE_COMPATIBLE}:g' ${WORKDIR}/system.conf
 }

--- a/recipes-core/rauc/rauc_rauc.inc
+++ b/recipes-core/rauc/rauc_rauc.inc
@@ -2,3 +2,8 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 # additional dependencies required to run RAUC on the target
 RDEPENDS:${PN} += "grub-editenv e2fsprogs-mke2fs"
+
+do_install:prepend () {
+  # Replace root block device name parameters
+  sed -i -e 's:@ROOT_BLOCK_DEVICE_NAME@:${ROOT_BLOCK_DEVICE_NAME}:g' ${WORKDIR}/system.conf
+}

--- a/recipes-core/rauc/rauc_rauc.inc
+++ b/recipes-core/rauc/rauc_rauc.inc
@@ -5,6 +5,7 @@ RDEPENDS:${PN} += "grub-editenv e2fsprogs-mke2fs"
 
 # Define compatible bundles (by default, same as RAUC)
 MSB_BUNDLE_COMPATIBLE ?= "${RAUC_BUNDLE_COMPATIBLE}"
+ROOT_BLOCK_DEVICE_NAME ?= "nvme0n1"
 
 do_install:prepend () {
   # Replace root block device name parameters

--- a/recipes-kernel/linux/linux-intel_%.bbappend
+++ b/recipes-kernel/linux/linux-intel_%.bbappend
@@ -1,4 +1,4 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += "file://intel-nuc.scc"
 


### PR DESCRIPTION
### Changes Overview

- **[Migrating to kirkstone and made build pass.](https://github.com/axians/meta-microservicebus-intel-nuc/commit/1c57c81a9e66bbc4e5543227d92b072067b2de64)** (1c57c81a9e66bbc4e5543227d92b072067b2de64)
  - Adapted the syntax (released in [Yocto 3.4](https://docs.yoctoproject.org/dev/migration-guides/release-3.4.html))
  - Edited LAYERSERIES_COMPAT to be kirkstone
  - Specifying exactly which file is imported by grub recipe in EFI_FILES_PATH
  - Changed provided grub-bootconf (see [oe-core 93ac180d8c389f16964bce8bd5538d9389e970e6](https://github.com/openembedded/openembedded-core/commit/93ac180d8c389f16964bce8bd5538d9389e970e6) and [Yocto #14538](https://bugzilla.yoctoproject.org/show_bug.cgi?id=14538))

- **[Made root block device name and boot cmdline configurable.](https://github.com/axians/meta-microservicebus-intel-nuc/commit/85f8424e500366ff38065b5a8f43124f06f2caa6)** (85f8424e500366ff38065b5a8f43124f06f2caa6)

- **[Added parameter to configure compatible bundle declared in system.conf](https://github.com/axians/meta-microservicebus-intel-nuc/commit/53329cce5563f6236dc63e632f6e9182438f3a90)** (53329cce5563f6236dc63e632f6e9182438f3a90)

### Added customization

- **`ROOT_BLOCK_DEVICE_NAME`**
  - Was added as our NUC devices *([Intel NUC Rugged Kit NUC8CCHKRN](https://ark.intel.com/content/www/us/en/ark/products/214634/intel-nuc-8-rugged-kit-nuc8cchkrn.html))* uses `mmcblk0` instead of `nvme0n1`.
  - Default value: `"nvme0n1"`

- **`BOOT_CMDLINE`**
  - Was added as `console=ttyS0,115200` was preventing the boot on our devices which was then stuck in a reboot/retry loop. We had to use `console=tty0`.
  - Default value: `"console=ttyS0,115200 net.ifnames=0 panic=60"`

- **`MSB_BUNDLE_COMPATIBLE`**
  - Was added as `intel-i7-x64-nuc-msb-rauc` might not match was is defined in `RAUC_BUNDLE_COMPATIBLE`
  - Default value: `${RAUC_BUNDLE_COMPATIBLE}`




